### PR TITLE
fix: expose CXXFLAGS to downstream deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 tmp
 .env
 pkg
+*.gem

--- a/ext/one_signal/capn_proto/extconf.rb
+++ b/ext/one_signal/capn_proto/extconf.rb
@@ -14,6 +14,8 @@ CONFIG['CXXFLAGS'] = [(ENV['CXXFLAGS'] || CONFIG['CXXFLAGS']),
                       compiler.std_flag,
                       compiler.stdlib_flag].join(' ')
 
+$CXXFLAGS = CONFIG['CXXFLAGS']
+
 if enable_config('debug')
   CONFIG['CFLAGS'] += " -O0 -ggdb3"
 else


### PR DESCRIPTION
This makes sure the gem’s native extensions compile as expected on macOS.

Before:

```
gem build one_signal-capn_proto
env CXXFLAGS=-std=c++14 gem install one_signal-capn_proto-0.0.3.gem

Building native extensions. This could take a while...
ERROR:  Error installing one_signal-capn_proto-0.0.3.gem:
	ERROR: Failed to build gem native extension.

…

/usr/local/include/kj/common.h:36:4: error: "This code requires C++14. Either your compiler does not support it or it is not enabled."
  #error "This code requires C++14. Either your compiler does not support it or it is not enabled."
```

After:

```
env CXXFLAGS=-std=c++14 gem install one_signal-capn_proto-0.0.3.gem

Building native extensions. This could take a while...
Successfully installed one_signal-capn_proto-0.0.3
1 gem installed
```

---

I realize the OneSignal Rails application runs inside a Unix-based container so installing this gem locally isn't required, but I still like to be able to run `bundle install` locally so that I can navigate through the code base using the configured language server.